### PR TITLE
Fix graph-node running error when using docker-compose file

### DIFF
--- a/packages/services/graph-node/docker-compose.yml
+++ b/packages/services/graph-node/docker-compose.yml
@@ -36,5 +36,7 @@ services:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph-node
+      PGDATA: "/var/lib/postgresql/data"
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
**Describe the bug**
A clear and concise description of what the bug is.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to 'services/graph-node'
2. Run  'docker-compose up'

Core dump:
`
graph-node_1  | thread 'Mar 27 07:01:04.951 CRIT Database does not use C locale. Please check the graph-node documentation for how to set up the database locale, error: database collation is `en_US.utf8` but must be `C`, pool: main, shard: primary, component: ConnectionPool
graph-node_1  | tokio-runtime-worker' panicked at 'Database does not use C locale. Please check the graph-node documentation for how to set up the database locale: database collation is `en_US.utf8` but must be `C`', store/postgres/src/connection_pool.rs:976:13
graph-node_1  | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
graph-node_1  | thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: JoinError::Panic(...)', /graph-node/store/postgres/src/connection_pool.rs:484:10
graph-node_graph-node_1 exited with code 101
`

**Solution**
update the compose file to newest official
refering to https://github.com/graphprotocol/graph-node/blob/master/docker/docker-compose.yml

